### PR TITLE
CI pipeline: GitHub Actions for tests, lint, and build #116

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: "CI"
 
 on:
   push:
@@ -15,20 +15,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: "Install dependencies"
         run: |
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
 
-      - name: Lint (flake8)
+      - name: "Lint (flake8)"
         run: pip install flake8 && flake8 backend/
 
-      - name: Run Django tests
+      - name: "Tests"
         run: |
           cd backend
           python manage.py test
@@ -38,17 +38,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Node.js
+      - name: "Set up Node.js"
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
-      - name: Install dependencies
+      - name: "Install dependencies"
         run: |
           cd frontend
           npm ci
 
-      - name: Build frontend
+      - name: "Build frontend"
         run: |
           cd frontend
           npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,16 @@ name: "CI"
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ develop ]
+    branches: [ main, develop ]
 
 jobs:
   backend:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11, 3.12]
+        python-version: [3.10, 3.11, 3.12, 3.13]
     steps:
       - uses: actions/checkout@v4
 
@@ -20,18 +20,25 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip 
+          key: ${{ runner.os }}-pip-${{ hashFiles("backend/requirements.txt") }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: "Install dependencies"
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==24.0
           pip install -r backend/requirements.txt
 
       - name: "Lint (flake8)"
-        run: pip install flake8 && flake8 backend/
+        run: pip install flake8==7.0.0 && flake8 backend/
 
       - name: "Tests"
-        run: |
-          cd backend
-          python manage.py test
+        run: python manage.py test
+        working-directory: backend        
 
   frontend:
     runs-on: ubuntu-latest
@@ -41,14 +48,26 @@ jobs:
       - name: "Set up Node.js"
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.11.1'
+
+      - name: Cache node modules
+        uses: actions/cache@v4 
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles("**/package-lock.json") }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: "Install dependencies"
-        run: |
-          cd frontend
-          npm ci
+        run: npm ci
+        working-directory: frontend
 
       - name: "Build frontend"
-        run: |
-          cd frontend
-          npm run build
+        run: npm run build
+        working-directory: frontend
+      
+      - name: Upload frontend build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+
+      - name: Lint (flake8)
+        run: pip install flake8 && flake8 backend/
+
+      - name: Run Django tests
+        run: |
+          cd backend
+          python manage.py test
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: |
+          cd frontend
+          npm ci
+
+      - name: Build frontend
+        run: |
+          cd frontend
+          npm run build

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ We are committed to delivering a platform that is not just a marketplace for ide
 
 ### CI/CD Workflow
 
-This project uses GitHub Actions for Continuous Integration. The workflow runs linters, tests, and builds for every pull request to the `develop` branch.
+This project uses GitHub Actions for Continuous Integration. The workflow runs for every pull request to the `develop` and `main` branches and includes two jobs:
+
+- **`backend`**: Lints the code and runs tests for the Django application.
+- **`frontend`**: Installs dependencies and builds the frontend application.
 
 #### How to Read CI Logs
 
@@ -93,3 +96,4 @@ This project uses GitHub Actions for Continuous Integration. The workflow runs l
 2.  Scroll down to the **Checks** section.
 3.  If the workflow fails, you will see a red 'X'. Click on the **Details** link next to the failing job (e.g., `backend` or `frontend`).
 4.  This will open the logs. Expand the step that failed (e.g., `Lint (flake8)` or `Tests`) to see the detailed error message.
+5.  To view build artifacts, go to the 'Artifacts' section under the job summary. (available only for frontend)

--- a/README.md
+++ b/README.md
@@ -83,5 +83,13 @@ We are committed to delivering a platform that is not just a marketplace for ide
 - Each user story can be broken down into smaller tasks and developed in sprints.
 - Regular feedback from both user groups (startups and investors) should be incorporated.
 
+### CI/CD Workflow
 
+This project uses GitHub Actions for Continuous Integration. The workflow runs linters, tests, and builds for every pull request to the `develop` branch.
 
+#### How to Read CI Logs
+
+1.  Open the **Pull Request** on GitHub.
+2.  Scroll down to the **Checks** section.
+3.  If the workflow fails, you will see a red 'X'. Click on the **Details** link next to the failing job (e.g., `backend` or `frontend`).
+4.  This will open the logs. Expand the step that failed (e.g., `Lint (flake8)` or `Tests`) to see the detailed error message.


### PR DESCRIPTION
linked issue - https://github.com/Project-Stage-Academy/UA-4252-Python-FS/issues/116

ci: add GitHub Actions workflow

Adds a CI pipeline that runs on every push and pull request to the 'develop' branch, and documentation how to read CI logs.

The workflow includes two jobs:
- 'backend': Lints and tests the Django application.
- 'frontend': Installs dependencies and builds the frontend.
