### PR TITLE
Backend: Custom authentication class to support JWT tokens stored in cookies

### DIFF
--- a/backend/apps/authentication/cookie_auth.py
+++ b/backend/apps/authentication/cookie_auth.py
@@ -1,0 +1,28 @@
+import logging
+
+from rest_framework.request import Request
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+
+logger = logging.getLogger(__name__)
+
+
+class CookieJWTAuthentication(JWTAuthentication):
+    def authenticate(self, request: Request):
+        header = self.get_header(request)
+
+        if header is not None:
+            # try to get the token from the Authorization header first
+            token = self.get_raw_token(header)
+        else:
+            # check for token in cookies
+            token = request.COOKIES.get("access_token")
+
+        if token is not None:
+            try:
+                validated_token = self.get_validated_token(token)
+                return self.get_user(validated_token), validated_token
+            except (InvalidToken, TokenError) as e:
+                logger.error(f"Token validation error: {str(e)}")
+
+        return None

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -150,7 +150,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "apps.authentication.cookie_auth.CookieJWTAuthentication",
     ),
 }
 
@@ -179,7 +179,6 @@ if os.environ.get("DJANGO_TEST", "0") == "1":
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "unique-for-testing",
     }
-
 
 EMAIL_BACKEND = os.environ.get(
     "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"


### PR DESCRIPTION
Added custom `CookieJWTAuthentication` class, which:

1. Checks for token, stored in Authorization header (default `simplejwt JWTAuthentication` behavior).
2. If token was not found in the header, checks for token in cookies.
3. Validates token if found, returns `AuthUser` instance with the validated token.
4. If token not found or is invalid, returns `None`, leading to `401 Unauthorized` error.